### PR TITLE
initialize and check buffers with the correct maximum length

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ read and write user data in between the usermode program and the kernel.
 
 
 # Overview
-See my [blog](https://blog.tofile.dev/2021/....) and my [DEF CON talk](https://defcon.org/html/defcon-29/dc-29-speakers.html#path) for an overview on how thee programs work and why this is interesting.
+See my [blog](https://blog.tofile.dev/2021/08/01/bad-bpf.html) and my [DEF CON talk](https://defcon.org/html/defcon-29/dc-29-speakers.html#path) for an overview on how thee programs work and why this is interesting.
 
 Examples have been tested on:
 - Ubuntu 20.10
@@ -73,17 +73,23 @@ This option restricts the programs' operation to only programs that are children
 of the process matching this PID. This demonstrates to how affect some programs, but not others.
 
 
-- [BPF-DOS](#BPF-Dos)
-- [Exec-Hijack](#Exec-Hijack)
-- [Pid-Hide](#Pid-Hide)
-- [Sudo-Add](#Sudo-Add)
-- [Write-Blocker](#Write-Blocker)
-- [Text-Replace](#Text-Replace)
-    - [Kernel Module hiding](#Text-Replace)
-    - [MAC Address spoofer](#Text-Replace)
-- [Text-Replace2](#Text-Replace2)
-    - [Altering Configuration](#Text-Replace2)
-    - [Running Detached](#Text-Replace2)
+- [Bad BPF](#bad-bpf)
+- [Overview](#overview)
+- [Build](#build)
+  - [Dependecies](#dependecies)
+  - [Build](#build-1)
+- [Run](#run)
+- [Programs](#programs)
+  - [Common Arguments](#common-arguments)
+  - [BPF-Dos](#bpf-dos)
+  - [Exec-Hijack](#exec-hijack)
+  - [Pid-Hide](#pid-hide)
+  - [Sudo-Add](#sudo-add)
+  - [Write-Blocker](#write-blocker)
+  - [Text-Replace](#text-replace)
+  - [Text-Replace2](#text-replace2)
+    - [Altering Configuration](#altering-configuration)
+    - [Running Detached](#running-detached)
 
 ## BPF-Dos
 ```bash

--- a/src/textreplace.bpf.c
+++ b/src/textreplace.bpf.c
@@ -65,8 +65,8 @@ const volatile char filename[filename_len_max];
 // These store the text to find and replace in the file
 const unsigned int text_len_max = 20;
 const volatile  unsigned int text_len = 0;
-const volatile char text_find[filename_len_max];
-const volatile char text_replace[filename_len_max];
+const volatile char text_find[text_len_max];
+const volatile char text_replace[text_len_max];
 
 SEC("tp/syscalls/sys_exit_close")
 int handle_close_exit(struct trace_event_raw_sys_exit *ctx)

--- a/src/textreplace.c
+++ b/src/textreplace.c
@@ -10,8 +10,8 @@
 #define text_len_max 20
 static struct env {
     char filename[filename_len_max];
-    char input[filename_len_max];
-    char replace[filename_len_max];
+    char input[text_len_max];
+    char replace[text_len_max];
     int target_ppid;
 } env;
 
@@ -44,14 +44,14 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
     switch (key) {
     case 'i':
         if (strlen(arg) >= text_len_max) {
-            fprintf(stderr, "Text must be less than %d characters\n", filename_len_max);
+            fprintf(stderr, "Text must be less than %d characters\n", text_len_max);
             argp_usage(state);
         }
         strncpy(env.input, arg, sizeof(env.input));
         break;
     case 'r':
         if (strlen(arg) >= text_len_max) {
-            fprintf(stderr, "Text must be less than %d characters\n", filename_len_max);
+            fprintf(stderr, "Text must be less than %d characters\n", text_len_max);
             argp_usage(state);
         }
         strncpy(env.replace, arg, sizeof(env.replace));


### PR DESCRIPTION
Thanks for sharing your great work on this.  I noticed that the find/replace buffers were being initialized and checked with the filename_len_max value instead of the text_len_max value.  This seems more consistent with what you intended.